### PR TITLE
Make Key lower case by using HTTPHeaders

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -52,7 +52,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			md = metadata.New(nil)
 		}
 		mdWriter := metadataReaderWriter{md}
-		err = tracer.Inject(clientSpan.Context(), opentracing.TextMap, mdWriter)
+		err = tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, mdWriter)
 		// We have no better place to record an error than the Span itself :-/
 		if err != nil {
 			clientSpan.LogEventWithPayload(

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -36,7 +36,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		if !ok {
 			md = metadata.New(nil)
 		}
-		spanContext, err := tracer.Extract(opentracing.TextMap, metadataReaderWriter{md})
+		spanContext, err := tracer.Extract(opentracing.HTTPHeaders, metadataReaderWriter{md})
 		if err != nil && err != opentracing.ErrSpanContextNotFound {
 			// TODO: establish some sort of error reporting mechanism here. We
 			// don't know where to put such an error and must rely on Tracer

--- a/go/otgrpc/shared.go
+++ b/go/otgrpc/shared.go
@@ -1,6 +1,8 @@
 package otgrpc
 
 import (
+	"strings"
+
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"google.golang.org/grpc/metadata"
@@ -18,6 +20,7 @@ type metadataReaderWriter struct {
 }
 
 func (w metadataReaderWriter) Set(key, val string) {
+	key = strings.ToLower(key)
 	w.MD[key] = append(w.MD[key], val)
 }
 


### PR DESCRIPTION
This changes the key mapper from TextMap to HTTPHeaders.

I integrated the work of @bajb in the commits to give him credit of the finding. 

I made this PR so it can be merged quicker as I need this fix in order to make it work with Zipkin. 
