### PR TITLE
Update deprecated LogEventWithPayload calls to LogFields instead

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -1,10 +1,9 @@
 package otgrpc
 
 import (
-	"fmt"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -55,22 +54,19 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		err = tracer.Inject(clientSpan.Context(), opentracing.HTTPHeaders, mdWriter)
 		// We have no better place to record an error than the Span itself :-/
 		if err != nil {
-			clientSpan.LogEventWithPayload(
-				"Tracer.Inject() failed", map[string]interface{}{
-					"error": fmt.Sprint(err),
-				})
+			clientSpan.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
 		}
 		ctx = metadata.NewContext(ctx, md)
 		if otgrpcOpts.logPayloads {
-			clientSpan.LogEventWithPayload("gRPC request", req)
+			clientSpan.LogFields(log.Object("gRPC request", req))
 		}
 		err = invoker(ctx, method, req, resp, cc, opts...)
 		if err == nil {
 			if otgrpcOpts.logPayloads {
-				clientSpan.LogEventWithPayload("gRPC response", resp)
+				clientSpan.LogFields(log.Object("gRPC response", resp))
 			}
 		} else {
-			clientSpan.LogEventWithPayload("gRPC error", err)
+			clientSpan.LogFields(log.String("event", "gRPC error"), log.Error(err))
 			ext.Error.Set(clientSpan, true)
 		}
 		if otgrpcOpts.decorator != nil {

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -1,8 +1,9 @@
 package otgrpc
 
 import (
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
+	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -51,16 +52,16 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 
 		ctx = opentracing.ContextWithSpan(ctx, serverSpan)
 		if otgrpcOpts.logPayloads {
-			serverSpan.LogEventWithPayload("gRPC request", req)
+			serverSpan.LogFields(log.Object("gRPC request", req))
 		}
 		resp, err = handler(ctx, req)
 		if err == nil {
 			if otgrpcOpts.logPayloads {
-				serverSpan.LogEventWithPayload("gRPC response", resp)
+				serverSpan.LogFields(log.Object("gRPC response", resp))
 			}
 		} else {
 			ext.Error.Set(serverSpan, true)
-			serverSpan.LogEventWithPayload("gRPC error", err)
+			serverSpan.LogFields(log.String("event", "gRPC error"), log.Error(err))
 		}
 		if otgrpcOpts.decorator != nil {
 			otgrpcOpts.decorator(serverSpan, info.FullMethod, req, resp, err)


### PR DESCRIPTION
**Reason**
`LogEvent` together with it's sister functions have been deprecated in OpenTracing. 

Error logging that is done through these deprecated functions might not be correctly 'translated' to the new `LogRecord` struct as it will require individual tracer implementations doing extra checks for an accurate translation. 