### PR TITLE
Add doNotStartTrace Option

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -39,7 +39,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		if parent := opentracing.SpanFromContext(ctx); parent != nil {
 			parentCtx = parent.Context()
 		}
-		if !otgrpcOpts.filter(parentCtx, method, req, resp) {
+		if !otgrpcOpts.include(parentCtx, method, req, resp) {
 			return invoker(ctx, method, req, resp, cc, opts...)
 		}
 		clientSpan := tracer.StartSpan(

--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -38,7 +38,8 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		var parentCtx opentracing.SpanContext
 		if parent := opentracing.SpanFromContext(ctx); parent != nil {
 			parentCtx = parent.Context()
-		} else if otgrpcOpts.doNotStartTrace {
+		}
+		if !otgrpcOpts.filter(parentCtx, method, req, resp) {
 			return invoker(ctx, method, req, resp, cc, opts...)
 		}
 		clientSpan := tracer.StartSpan(

--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -38,6 +38,8 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		var parentCtx opentracing.SpanContext
 		if parent := opentracing.SpanFromContext(ctx); parent != nil {
 			parentCtx = parent.Context()
+		} else if otgrpcOpts.doNotStartTrace {
+			return invoker(ctx, method, req, resp, cc, opts...)
 		}
 		clientSpan := tracer.StartSpan(
 			method,

--- a/go/otgrpc/options.go
+++ b/go/otgrpc/options.go
@@ -17,18 +17,18 @@ func LogPayloads() Option {
 	}
 }
 
-// SpanFilterFunc provides an optional mechanism to decided whether or not
+// IncludeSpanFunc provides an optional mechanism to decide whether or not
 // to trace a given gRPC call. Return true to create a Span and initiate
 // tracing, false to not create a Span and not trace
-type SpanFilterFunc func(
+type IncludeSpanFunc func(
 	parentSpanCtx opentracing.SpanContext,
 	method string,
 	req, resp interface{}) bool
 
-// SpanFilter binds a SpanFilterFunc to the options
-func SpanFilter(filter SpanFilterFunc) Option {
+// IncludeSpan binds a IncludeSpanFunc to the options
+func IncludeSpan(include IncludeSpanFunc) Option {
 	return func(o *options) {
-		o.filter = filter
+		o.include = include
 	}
 }
 
@@ -54,14 +54,14 @@ func SpanDecorator(decorator SpanDecoratorFunc) Option {
 type options struct {
 	logPayloads bool
 	decorator   SpanDecoratorFunc
-	filter      SpanFilterFunc
+	include     IncludeSpanFunc
 }
 
 // newOptions returns the default options.
 func newOptions() *options {
 	return &options{
 		logPayloads: false,
-		filter: func(parentSpanCtx opentracing.SpanContext,
+		include: func(parentSpanCtx opentracing.SpanContext,
 			method string,
 			req, resp interface{}) bool {
 			return true

--- a/go/otgrpc/options.go
+++ b/go/otgrpc/options.go
@@ -17,6 +17,14 @@ func LogPayloads() Option {
 	}
 }
 
+// DoNotStartTrace returns an Option that tells the OpenTracing instrumentation to
+// only trace if the context already contains a Span; do not start a new Span
+func DoNotStartTrace() Option {
+	return func(o *options) {
+		o.doNotStartTrace = true
+	}
+}
+
 // SpanDecoratorFunc provides an (optional) mechanism for otgrpc users to add
 // arbitrary tags/logs/etc to the opentracing.Span associated with client
 // and/or server RPCs.
@@ -39,12 +47,14 @@ func SpanDecorator(decorator SpanDecoratorFunc) Option {
 type options struct {
 	logPayloads bool
 	decorator   SpanDecoratorFunc
+	doNotStartTrace bool
 }
 
 // newOptions returns the default options.
 func newOptions() *options {
 	return &options{
 		logPayloads: false,
+		doNotStartTrace: false,
 	}
 }
 

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -43,7 +43,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			// don't know where to put such an error and must rely on Tracer
 			// implementations to do something appropriate for the time being.
 		}
-		if !otgrpcOpts.filter(spanContext, info.FullMethod, req, nil) {
+		if !otgrpcOpts.include(spanContext, info.FullMethod, req, nil) {
 			return handler(ctx, req)
 		}
 		serverSpan := tracer.StartSpan(

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -42,6 +42,8 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			// TODO: establish some sort of error reporting mechanism here. We
 			// don't know where to put such an error and must rely on Tracer
 			// implementations to do something appropriate for the time being.
+		} else if err == opentracing.ErrSpanContextNotFound && otgrpcOpts.doNotStartTrace {
+			return handler(ctx, req)
 		}
 		serverSpan := tracer.StartSpan(
 			info.FullMethod,

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -42,7 +42,8 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			// TODO: establish some sort of error reporting mechanism here. We
 			// don't know where to put such an error and must rely on Tracer
 			// implementations to do something appropriate for the time being.
-		} else if err == opentracing.ErrSpanContextNotFound && otgrpcOpts.doNotStartTrace {
+		}
+		if !otgrpcOpts.filter(spanContext, info.FullMethod, req, nil) {
 			return handler(ctx, req)
 		}
 		serverSpan := tracer.StartSpan(


### PR DESCRIPTION
The is option will only trace gRPC calls if the Context already
contains a Span. This allows the caller to choose if any given
request is traced or not.