### PR TITLE
Updated error handling to follow OpenTracing semantic_conventions.md.

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -72,7 +72,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 				clientSpan.LogFields(log.Object("gRPC response", resp))
 			}
 		} else {
-			clientSpan.LogFields(log.String("event", "gRPC error"), log.Error(err))
+			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
 			ext.Error.Set(clientSpan, true)
 		}
 		if otgrpcOpts.decorator != nil {

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -65,7 +65,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			}
 		} else {
 			ext.Error.Set(serverSpan, true)
-			serverSpan.LogFields(log.String("event", "gRPC error"), log.Error(err))
+			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
 		}
 		if otgrpcOpts.decorator != nil {
 			otgrpcOpts.decorator(serverSpan, info.FullMethod, req, resp, err)


### PR DESCRIPTION
Updated the error logging to follow these [conventions](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#captured-errors) ([#22](https://github.com/grpc-ecosystem/grpc-opentracing/issues/22)).