### PR TITLE
Fix for grpc-go 1.3.0 metadata API

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -50,7 +50,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			gRPCComponentTag,
 		)
 		defer clientSpan.Finish()
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromOutgoingContext(ctx)
 		if !ok {
 			md = metadata.New(nil)
 		} else {
@@ -62,7 +62,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		if err != nil {
 			clientSpan.LogFields(log.String("event", "Tracer.Inject() failed"), log.Error(err))
 		}
-		ctx = metadata.NewContext(ctx, md)
+		ctx = metadata.NewOutgoingContext(ctx, md)
 		if otgrpcOpts.logPayloads {
 			clientSpan.LogFields(log.Object("gRPC request", req))
 		}

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -33,7 +33,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (resp interface{}, err error) {
-		md, ok := metadata.FromContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 		if !ok {
 			md = metadata.New(nil)
 		}

--- a/go/otgrpc/shared.go
+++ b/go/otgrpc/shared.go
@@ -32,11 +32,7 @@ func (w metadataReaderWriter) Set(key, val string) {
 func (w metadataReaderWriter) ForeachKey(handler func(key, val string) error) error {
 	for k, vals := range w.MD {
 		for _, v := range vals {
-			if dk, dv, err := metadata.DecodeKeyValue(k, v); err == nil {
-				if err = handler(dk, dv); err != nil {
-					return err
-				}
-			} else {
+			if err := handler(k, v); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
This fixes https://github.com/grpc-ecosystem/grpc-opentracing/issues/28 re https://github.com/grpc/grpc-go/issues/1219. This also removes the usage of `metadata.DecodeKeyValue` since this method was deprecated and is now a no-op.