### PR TITLE
Fix NPE in Client filter

### DIFF
--- a/java/src/main/java/io/opentracing/contrib/ClientTracingInterceptor.java
+++ b/java/src/main/java/io/opentracing/contrib/ClientTracingInterceptor.java
@@ -150,7 +150,13 @@ public class ClientTracingInterceptor implements ClientInterceptor {
                     public void onClose(Status status, Metadata trailers) {
                         if (verbose) { 
                             if (status.getCode().value() == 0) { span.log("Call closed"); }
-                            else { span.log(ImmutableMap.of("Call failed", status.getDescription())); }
+                            else if (status.getDescription() != null) {
+                                span.log(ImmutableMap.of("Call failed", status.getCode(),
+						"Failure", status.getDescription()));
+                            } 
+                            else {
+                                span.log(ImmutableMap.of("Call failed ", status.getCode()));
+                            }
                         }
                         span.finish();
                         delegate().onClose(status, trailers);


### PR DESCRIPTION
Servers can return status codes without a description. In that case, it returns `null` which causes an NPE in the `ImmutableMap` implementation. This only adds the description if set, and otherwise just logs the error code.