### PR TITLE
Don't flag errors in class "Success"

### DIFF
--- a/go/otgrpc/errors.go
+++ b/go/otgrpc/errors.go
@@ -63,7 +63,7 @@ func SetSpanTags(span opentracing.Span, err error, client bool) {
 	if err == nil {
 		return
 	}
-	if client || c == ServerError {
+	if c != Success && (client || c == ServerError) {
 		ext.Error.Set(span, true)
 	}
 }


### PR DESCRIPTION
E.g. if the operation was cancelled, that's not an error.

Fixes #44 