### PR TITLE
Add ctx in SpanDecorator option

### DIFF
--- a/go/otgrpc/client.go
+++ b/go/otgrpc/client.go
@@ -1,15 +1,16 @@
 package otgrpc
 
 import (
-	"github.com/opentracing/opentracing-go"
+	"io"
+	"runtime"
+	"sync/atomic"
+
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"io"
-	"runtime"
-	"sync/atomic"
 )
 
 // OpenTracingClientInterceptor returns a grpc.UnaryClientInterceptor suitable
@@ -67,7 +68,7 @@ func OpenTracingClientInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			clientSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
 		}
 		if otgrpcOpts.decorator != nil {
-			otgrpcOpts.decorator(clientSpan, method, req, resp, err)
+			otgrpcOpts.decorator(ctx, clientSpan, method, req, resp, err)
 		}
 		return err
 	}
@@ -147,7 +148,7 @@ func newOpenTracingClientStream(cs grpc.ClientStream, method string, desc *grpc.
 			SetSpanTags(clientSpan, err, true)
 		}
 		if otgrpcOpts.decorator != nil {
-			otgrpcOpts.decorator(clientSpan, method, nil, nil, err)
+			otgrpcOpts.decorator(context.Background(), clientSpan, method, nil, nil, err)
 		}
 	}
 	go func() {

--- a/go/otgrpc/options.go
+++ b/go/otgrpc/options.go
@@ -1,6 +1,9 @@
 package otgrpc
 
-import "github.com/opentracing/opentracing-go"
+import (
+	opentracing "github.com/opentracing/opentracing-go"
+	"golang.org/x/net/context"
+)
 
 // Option instances may be used in OpenTracing(Server|Client)Interceptor
 // initialization.
@@ -39,6 +42,7 @@ func IncludingSpans(inclusionFunc SpanInclusionFunc) Option {
 // arbitrary tags/logs/etc to the opentracing.Span associated with client
 // and/or server RPCs.
 type SpanDecoratorFunc func(
+	ctx context.Context,
 	span opentracing.Span,
 	method string,
 	req, resp interface{},

--- a/go/otgrpc/server.go
+++ b/go/otgrpc/server.go
@@ -1,7 +1,7 @@
 package otgrpc
 
 import (
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/opentracing/opentracing-go/log"
 	"golang.org/x/net/context"
@@ -64,7 +64,7 @@ func OpenTracingServerInterceptor(tracer opentracing.Tracer, optFuncs ...Option)
 			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
 		}
 		if otgrpcOpts.decorator != nil {
-			otgrpcOpts.decorator(serverSpan, info.FullMethod, req, resp, err)
+			otgrpcOpts.decorator(ctx, serverSpan, info.FullMethod, req, resp, err)
 		}
 		return resp, err
 	}
@@ -117,7 +117,7 @@ func OpenTracingStreamServerInterceptor(tracer opentracing.Tracer, optFuncs ...O
 			serverSpan.LogFields(log.String("event", "error"), log.String("message", err.Error()))
 		}
 		if otgrpcOpts.decorator != nil {
-			otgrpcOpts.decorator(serverSpan, info.FullMethod, nil, nil, err)
+			otgrpcOpts.decorator(context.Background(), serverSpan, info.FullMethod, nil, nil, err)
 		}
 		return err
 	}


### PR DESCRIPTION
I needed to add specific tag from contextKey set in the context on an other middleware before this one.

I wasn't able to access it without adding the context in the decorator.